### PR TITLE
Flip fileCreationDate and fileCreationTime fields to match ACH spec

### DIFF
--- a/payroll.ts
+++ b/payroll.ts
@@ -9,8 +9,8 @@ const fh: FileHeader = {
     immediateOriginName: "My Bank Name",
     immediateDestination: "071000301",
     immediateDestinationName: "FRBATLANTA",
-    fileCreationTime: "190816", // dynamic, current day - YYMMDD. Y=Year, M=Month, D=Day
-    fileCreationDate: "1055",   // dynamic, currnet day - HHmm. H=Hour, m=Minute;
+    fileCreationDate: "190816", // dynamic, current day - YYMMDD. Y=Year, M=Month, D=Day
+    fileCreationTime: "1055",   // dynamic, currnet day - HHmm. H=Hour, m=Minute;
     fileIDModifier: 'M'
 }
 //Build the Batch Header


### PR DESCRIPTION
I believe these fields are flipped here - fileCreationDate should be the 6 position 'YYMMDD' field and fileCreationTime should be the 4 position 'HHMM' field... just a small nit I noticed!